### PR TITLE
initial commit of windows_build vagrantfile

### DIFF
--- a/windows-build/Vagrantfile
+++ b/windows-build/Vagrantfile
@@ -67,6 +67,7 @@ Vagrant.configure(2) do |config|
   # end
 
   #config.vm.provision :shell, path: "shell/main.cmd"
+  config.vm.provision "shell", inline: "cmd.exe /c ""IF NOT EXIST C:\tmp MKDIR C:\tmp"""
   #config.vm.provision :shell, path: "shell/InstallBoxStarter.bat"
   #config.vm.provision "file",
   #                    source: "shell/RunBoxStarterGist.bat",
@@ -78,6 +79,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision :salt do |salt|
     # run locally, don't wait for master to tell it what to do
     salt.masterless = true
+
+    salt.version = "2016.3.2"
 
     # Relative location of configuration file to use for minion
     # since we need to tell our minion to run in masterless mode

--- a/windows-build/Vagrantfile
+++ b/windows-build/Vagrantfile
@@ -1,0 +1,96 @@
+# coding: utf-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  config.ssh.insert_key = false
+  config.ssh.port = 22
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "opentable/win-2012r2-standard-amd64-nocm"
+  config.vm.communicator = "winrm"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "4096"
+    vb.cpus = 2
+    vb.customize ["modifyvm", :id, "--vram", "128"]
+    vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    vb.name = "Windows Python Builder"
+  end
+
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  #config.vm.provision :shell, path: "shell/main.cmd"
+  #config.vm.provision :shell, path: "shell/InstallBoxStarter.bat"
+  #config.vm.provision "file",
+  #                    source: "shell/RunBoxStarterGist.bat",
+  #                    destination: "desktop\\RunBoxStarterGist.bat"
+
+  config.vm.synced_folder "saltstack/", "/srv/saltstack"
+
+  # Salt Provisioner
+  config.vm.provision :salt do |salt|
+    # run locally, don't wait for master to tell it what to do
+    salt.masterless = true
+
+    # Relative location of configuration file to use for minion
+    # since we need to tell our minion to run in masterless mode
+    salt.minion_config = "saltstack/etc/minion"
+
+    # On provision, run state.highstate (which installs packages, services, etc).
+    # Highstate basically means "comapre the VMs current machine state against
+    # what it should be and make changes if necessary".
+    salt.run_highstate = true
+
+    # Run in verbose mode, so it will output all debug info to the console.
+    # This is nice to have when you are testing things out. Once you know they
+    # work well you can comment this line out.
+    salt.verbose = true
+  end
+end

--- a/windows-build/saltstack/etc/minion
+++ b/windows-build/saltstack/etc/minion
@@ -1,0 +1,14 @@
+## originally from https://github.com/JustinCarmony/vagrant-salt-example/blob/master/saltstack/etc/minion
+
+## Look locally for files
+#master: localhost
+file_client: local
+
+## Where your salt states & files are located
+file_roots:
+  base:
+    - /srv/saltstack/salt
+
+pillar_roots:
+  base:
+    - /srv/saltstack/pillars

--- a/windows-build/saltstack/salt/7za.sls
+++ b/windows-build/saltstack/salt/7za.sls
@@ -5,6 +5,6 @@
 
 conda-build:
   cmd.run:
-    - name: 'C:\MC3x64\Scripts\conda.exe install -yq conda-build vs2015_runtime'
+    - name: 'C:\MC3x64\Scripts\conda.exe install -yq 7za'
     - require:
       - sls: miniconda3

--- a/windows-build/saltstack/salt/chocolatey.sls
+++ b/windows-build/saltstack/salt/chocolatey.sls
@@ -1,0 +1,3 @@
+chocolatey:
+  module.run:
+    - name: chocolatey.bootstrap

--- a/windows-build/saltstack/salt/chocolatey.sls
+++ b/windows-build/saltstack/salt/chocolatey.sls
@@ -1,3 +1,0 @@
-chocolatey:
-  module.run:
-    - name: chocolatey.bootstrap

--- a/windows-build/saltstack/salt/conda-build.sls
+++ b/windows-build/saltstack/salt/conda-build.sls
@@ -1,0 +1,5 @@
+conda-build:
+  cmd.run:
+    - name: 'C:\Miniconda\Scripts\conda.exe update conda && C:\Miniconda\Scripts\conda.exe install -y conda-build'
+    - require:
+      - module: miniconda3

--- a/windows-build/saltstack/salt/downloads.sls
+++ b/windows-build/saltstack/salt/downloads.sls
@@ -1,0 +1,3 @@
+C:\Downloads:
+  file.directory:
+    - makedirs: True

--- a/windows-build/saltstack/salt/git.sls
+++ b/windows-build/saltstack/salt/git.sls
@@ -3,8 +3,8 @@
 {% set env_path = salt['environ.get']('PATH') %}
 {% set env_path = env_path ~ ';' ~ conda_dir %}
 
-conda-build:
+install_m2_git:
   cmd.run:
-    - name: 'C:\MC3x64\Scripts\conda.exe install -yq conda-build vs2015_runtime'
+    - name: 'C:\MC3x64\Scripts\conda.exe install -yq m2-git posix'
     - require:
       - sls: miniconda3

--- a/windows-build/saltstack/salt/miniconda3.sls
+++ b/windows-build/saltstack/salt/miniconda3.sls
@@ -1,9 +1,20 @@
-{% set conda_dir = 'C:\\Miniconda\\;C:\\Miniconda\\Scripts;C:\\Miniconda\\Library\\bin' %}
-{% set env_path = salt['environ.get']('PATH') %}
-{% set env_path = env_path ~ ';' ~ conda_dir %}
+C:\Downloads\Miniconda3-4.1.11-Windows-x86_64.exe:
+  file.managed:
+    - name: C:\Downloads\Miniconda3-latest-Windows-x86_64.exe
+    - source: https://repo.continuum.io/miniconda/Miniconda3-4.1.11-Windows-x86_64.exe
+    - source_hash: md5=6c434573474edfc72b1408762b50dde3
+    - requires:
+      - module: download
 
 miniconda3:
   cmd.run:
-    - name: 'C:\ProgramData\chocolatey\bin\cinst -y miniconda3'
+    - shell: cmd
+    - name: 'start /wait "" C:\Downloads\Miniconda3-4.1.11-Windows-x86_64.exe /S /D=C:\MC3_x64'
     - require:
-      - module: chocolatey
+      - file: C:\Downloads\Miniconda3-4.1.11-Windows-x86_64.exe
+
+update_conda:
+  cmd.run:
+    - name: 'C:\MC3x64\Scripts\conda.exe update -yq conda'
+    - require:
+      - miniconda3: cmd.run

--- a/windows-build/saltstack/salt/miniconda3.sls
+++ b/windows-build/saltstack/salt/miniconda3.sls
@@ -1,0 +1,9 @@
+{% set conda_dir = 'C:\\Miniconda\\;C:\\Miniconda\\Scripts;C:\\Miniconda\\Library\\bin' %}
+{% set env_path = salt['environ.get']('PATH') %}
+{% set env_path = env_path ~ ';' ~ conda_dir %}
+
+miniconda3:
+  cmd.run:
+    - name: 'C:\ProgramData\chocolatey\bin\cinst -y miniconda3'
+    - require:
+      - module: chocolatey

--- a/windows-build/saltstack/salt/top.sls
+++ b/windows-build/saltstack/salt/top.sls
@@ -1,0 +1,8 @@
+base:
+  '*':
+    - chocolatey
+    - vc9
+    - vc10
+    - vc14
+    - miniconda3
+    - conda-build

--- a/windows-build/saltstack/salt/top.sls
+++ b/windows-build/saltstack/salt/top.sls
@@ -1,8 +1,9 @@
 base:
   '*':
-    - chocolatey
+    - downloads
     - vc9
     - vc10
     - vc14
     - miniconda3
     - conda-build
+    - git

--- a/windows-build/saltstack/salt/vc10.sls
+++ b/windows-build/saltstack/salt/vc10.sls
@@ -1,0 +1,5 @@
+vc10:
+  cmd.run:
+    - name: 'C:\ProgramData\chocolatey\bin\cinst -y windows-sdk-7.1'
+    - require:
+      - module: chocolatey

--- a/windows-build/saltstack/salt/vc10.sls
+++ b/windows-build/saltstack/salt/vc10.sls
@@ -1,5 +1,21 @@
-vc10:
+C:\Downloads\GRMSDKX_EN_DVD.iso:
+  file.managed:
+    - name: C:\Downloads\GRMSDKX_EN_DVD.iso
+    - source: http://download.microsoft.com/download/F/1/0/F10113F5-B750-4969-A255-274341AC6BCE/GRMSDKX_EN_DVD.iso
+    - source_hash: sha256=9f495e52f33d68125277cbca3565ce57904af7d506758a14691fa6e2479ad65c
+    - requires:
+      - sls: download
+
+vc10-extract:
   cmd.run:
-    - name: 'C:\ProgramData\chocolatey\bin\cinst -y windows-sdk-7.1'
+    - name: '7za x -o C:\Downloads\Win7SDK -y C:\Downloads\GRMSDKX_EN_DVD.iso'
+    - creates: C:\Downloads\Win7SDK
     - require:
-      - module: chocolatey
+      - sls: 7za
+      - file: C:\Downloads\GRMSDKX_EN_DVD.iso
+
+vc10-install:
+  cmd.run:
+    - name: 'C:\Downloads\Win7SDK\setup.exe -q -params:ADDLOCAL=ALL'
+    - require:
+      - file: C:\Downloads\Win7SDK

--- a/windows-build/saltstack/salt/vc14.sls
+++ b/windows-build/saltstack/salt/vc14.sls
@@ -1,0 +1,5 @@
+vc14:
+  cmd.run:
+    - name: 'C:\ProgramData\chocolatey\bin\cinst -y visualcppbuildtools'
+    - require:
+      - module: chocolatey

--- a/windows-build/saltstack/salt/vc14.sls
+++ b/windows-build/saltstack/salt/vc14.sls
@@ -1,5 +1,22 @@
+C:\Downloads\BuildTools2015Admin.xml:
+  file.managed:
+    - name:   C:\Downloads\BuildTools2015Admin.xml
+    - source: https://gist.githubusercontent.com/msarahan/2342635a842ce93c9509801177076f8c/raw/0fa94a75794ed7df856098182fc604efd9f73ad7/AdminDeployment.xml
+    - source_hash: sha256=e4486732ed703e7f8907e429ae88ac1b18715061ef74e7877fa1a823d3a0f2e3
+    - requires:
+      - module: download
+
+C:\Downloads\visualcppbuildtools_full.exe:
+  file.managed:
+    - name:   C:\Downloads\visualcppbuildtools_full.exe
+    - source: http://download.microsoft.com/download/5/d/6/5d6a1865-11ff-41f8-8af6-60e92d9bbd0b/visualcppbuildtools_full.exe
+    - source_hash: sha256=4a72493b317b14eef590e9de8befce32ee2b1f49840e68495683200aa21abb6b
+    - requires:
+      - module: download
+
 vc14:
   cmd.run:
-    - name: 'C:\ProgramData\chocolatey\bin\cinst -y visualcppbuildtools'
+    - name: 'C:\Downloads\visualcppbuildtools_full.exe /Quiet /NoRestart /AdminFile C:\Downloads\BuildTools2015Admin.xml'
     - require:
-      - module: chocolatey
+      - file: C:\Downloads\visualcppbuildtools_full.exe
+      - file: C:\Downloads\BuildTools2015Admin.xml

--- a/windows-build/saltstack/salt/vc9.sls
+++ b/windows-build/saltstack/salt/vc9.sls
@@ -1,5 +1,13 @@
+C:\Downloads\VCForPython27.msi:
+  file.managed:
+    - name: C:\Downloads\VCForPython27.msi
+    - source: https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi
+    - source_hash: sha256=070474db76a2e625513a5835df4595df9324d820f9cc97eab2a596dcbc2f5cbf
+    - requires:
+      - module: download
+
 vc9:
   cmd.run:
-    - name: 'C:\ProgramData\chocolatey\bin\cinst  -y vcpython27'
+    - name: C:\Downloads\VCForPython27.msi /qn /norestart
     - require:
-      - module: chocolatey
+      - file: C:\Downloads\VCForPython27.msi

--- a/windows-build/saltstack/salt/vc9.sls
+++ b/windows-build/saltstack/salt/vc9.sls
@@ -1,0 +1,5 @@
+vc9:
+  cmd.run:
+    - name: 'C:\ProgramData\chocolatey\bin\cinst  -y vcpython27'
+    - require:
+      - module: chocolatey


### PR DESCRIPTION
This PR depends on a PR to Vagrant's salt provisioner.  See https://github.com/mitchellh/vagrant/pull/7207 - and apply this to your local vagrant installation before testing this vagrantfile.

Also, note that Vagrant does not update the worker's PATH after each installation.  This total setup should succeed, but you should either reboot the VM or log out and back in to the VM.  There should be ways to update those, but they seem to break salt's masterless provisioning, and trigger hangs as the minion waits for a non-existing master.
