### PR TITLE
Update images address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # vagrant-images
 Repository of Vagrant images created by Continuum Analytics.
 
-Currently images are available under below address:
-https://atlas.hashicorp.com/irritum/
-
-However in the nearest future they will be published here:
-https://atlas.hashicorp.com/continuumio/
+Images are available here:
+https://app.vagrantup.com/continuumio


### PR DESCRIPTION
Vagrant boxes are now published on https://app.vagrantup.com.